### PR TITLE
Allow mobile nav menu to expand fully

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -241,10 +241,10 @@ footer{ background: linear-gradient(90deg, var(--blue-900), var(--blue)); color:
     background: linear-gradient(90deg, var(--blue-900), var(--blue));
     flex-direction: column; gap: 0;
     max-height: 0; overflow: hidden;
-    transition: max-height .3s ease;
+    transition: max-height .35s ease;
     border-bottom-left-radius: 12px; border-bottom-right-radius: 12px;
   }
-  nav .nav-list.open { max-height: 300px; }
+  nav .nav-list.open { max-height: 100vh; }
   nav .nav-list a { display: block; padding: 14px 18px; }
 
   .gradient-hero{ min-height: 80vh; }


### PR DESCRIPTION
## Summary
- allow the mobile navigation drawer to grow to the viewport height so longer menus stay visible
- lengthen the max-height transition slightly for a smoother expansion

## Testing
- manual: opened index.html at 390px width, toggled the navigation menu, and confirmed all links are visible

------
https://chatgpt.com/codex/tasks/task_e_68e13def9dac8329af9651311db0833b